### PR TITLE
Feature/command line parameters

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./bin/Debug/raytracing.exe
+./bin/Debug/raytracing.exe --output=test.ppm --width=200 --height=100 --samples=8

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRC
         hitablelist.h
         camera.h
         material.h
+        parser.h
 )
 
 add_executable(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,16 +9,19 @@
 #include "hitablelist.h"
 #include "camera.h"
 #include "material.h"
+#include "parser.h"
 
 
 Color ray_color(const Ray &r, Hitable *world, int depth);
 
 
-int main()
+int main(int argc, char *argv[])
 {
-    Image image("test_camera_defocus.ppm");
+    auto input_data = parser(argc, argv);
 
-    auto samples = 8;
+    Image image(input_data.output_path, input_data.width, input_data.height);
+
+    auto samples = input_data.samples;
     
     Hitable *list[4];
 
@@ -39,7 +42,7 @@ int main()
         lookfrom,
         lookat,
         Vec3::Y,
-        20,
+        35,
         static_cast<float>(image.width()) / static_cast<float>(image.height()),
         aperture,
         focal_length

--- a/src/parser.h
+++ b/src/parser.h
@@ -1,0 +1,51 @@
+#ifndef RAYTRACING_PARSER_H
+#define RAYTRACING_PARSER_H
+
+
+#include <string>
+
+
+struct Parameter
+{
+    int width = 200;
+    int height = 100;
+    int samples = 8;
+    std::string output_path = "temp.ppm";
+};
+
+
+Parameter parser(int argc, char *argv[])
+{
+    Parameter out_param;
+
+    for(std::size_t idx=0; idx<argc; ++idx)
+    {
+        std::string arg(argv[idx]);
+        std::size_t pos = 0;
+
+        while((pos = arg.find('=')) != std::string::npos)
+        {
+            auto param = arg.substr(0, pos);
+            auto value = arg.substr(pos+1, arg.length());
+
+            if (param == "--output")
+                out_param.output_path = value;
+
+            if (param == "--width")
+                out_param.width = std::stoi(value);
+
+            if (param == "--height")
+                out_param.height = std::stoi(value);
+
+            if (param == "--samples")
+                out_param.samples = std::stoi(value);
+
+            arg.erase(0, pos + 1);
+        }
+    }
+
+    return out_param;
+}
+
+
+#endif //RAYTRACING_PARSER_H


### PR DESCRIPTION
Command argument parameter functionality.

Now we can define custom image resolution, output and samples, using command arguments.

If no argument is specified, the default values will be used: `width 200`, `height 100`, `samples 8`, `output temp.ppm`.

I've also updated the `run.sh` script for windows. Let me know if that causes you some problem.