### PR TITLE
Feature/motion blur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@
 
 build/
 bin/
+.idea/
 
 *.ppm
+
+.DS_Store

--- a/README.MD
+++ b/README.MD
@@ -4,8 +4,18 @@
 | develop | [![Build Status](https://travis-ci.org/raytracingDevTeam/raytracing.svg?branch=develop)](https://travis-ci.org/raytracingDevTeam/raytracing) | [![Build status](https://ci.appveyor.com/api/projects/status/1mi2agvpc8ln8ffi/branch/master?svg=true)](https://ci.appveyor.com/project/andrearastelli/raytracing/branch/develop) |
 | all || [![Build status](https://ci.appveyor.com/api/projects/status/1mi2agvpc8ln8ffi?svg=true)](https://ci.appveyor.com/project/andrearastelli/raytracing) |
 
-
 # Raytracing in One Weekend and beyond
+
+## 1.0.0
+![Imgur](https://i.imgur.com/KLX1Kv6.png)
+
+Image info:
+- 48 spheres (ground + 3 main spheres + 44 small spheres)
+- 800 x 400 pixel of resolution
+- 8 samples per pixel
+- 122.880.000 rays fired to generate the image.
+
+> In the current image, with the current sample count, will be extremely diffucult to identify metal from lambert materials, but with a higher (and most reasonable) sample count, let's say 128 or even 64, the total amount of rays generated will be 1.966.080.000, almost 2 Billion (128 sample, with 64 will be 1 Billion), and for a single threaded application this may be a little overkill.
 
 ## References
 - [Raytracing in a Weekend](http://amzn.eu/3JyrhOX)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SRC
         camera.h
         material.h
         parser.h
+        movingsphere.h
 )
 
 add_executable(

--- a/src/camera.h
+++ b/src/camera.h
@@ -31,6 +31,8 @@ private:
     Vec3 vertical;
     Vec3 u, v, w;
     float lens_radius;
+    float time0;
+    float time1;
 
 public:
 
@@ -69,6 +71,21 @@ public:
      * @param focus_dist
      */
     Camera(Vec3 lookfrom, Vec3 lookat, Vec3 up, float vfov, float aspect, float aperture, float focus_dist);
+
+
+    /**
+     *
+     * @param lookfrom
+     * @param lookat
+     * @param up
+     * @param vfov
+     * @param aspect
+     * @param aperture
+     * @param focus_dist
+     * @param t0
+     * @param t1
+     */
+    Camera(Vec3 lookfrom, Vec3 lookat, Vec3 up, float vfov, float aspect, float aperture, float focus_dist, float t0, float t1);
 
 
     /**
@@ -136,14 +153,38 @@ Camera::Camera(Vec3 lookfrom, Vec3 lookat, Vec3 up, float vfov, float aspect, fl
 }
 
 
+Camera::Camera(Vec3 lookfrom, Vec3 lookat, Vec3 up, float vfov, float aspect, float aperture, float focus_dist, float t0, float t1)
+{
+    time0 = t0;
+    time1 = t1;
+    lens_radius = aperture / 2.0f;
+
+    auto theta = static_cast<float>(vfov * M_PI / 180.0f);
+    auto half_height = tan(theta / 2.0f);
+    auto half_width = aspect * half_height;
+
+    origin = lookfrom;
+
+    w = unit_vector(lookfrom - lookat);
+    u = unit_vector(cross(up, w));
+    v = cross(w, u);
+
+    lower_left_corner = origin - half_width * focus_dist * u - half_height * focus_dist * v - focus_dist * w;
+    horizontal = 2.0f * half_width * focus_dist * u;
+    vertical = 2.0f * half_height * focus_dist * v;
+}
+
+
 Ray Camera::get_ray(float s, float t)
 {
     auto rd = lens_radius * random_in_unit_disc();
     auto offset = u * rd.x() + v * rd.y();
+    auto time = time0 + dist(m) * (time1 - time0);
 
     return {
         origin + offset,
-        lower_left_corner + s * horizontal + t * vertical - origin - offset
+        lower_left_corner + s * horizontal + t * vertical - origin - offset,
+        time
     };
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,9 @@
 Color ray_color(const Ray &r, Hitable *world, int depth);
 
 
+Hitable *random_scene();
+
+
 int main(int argc, char *argv[])
 {
     auto input_data = parser(argc, argv);
@@ -22,18 +25,10 @@ int main(int argc, char *argv[])
     Image image(input_data.output_path, input_data.width, input_data.height);
 
     auto samples = input_data.samples;
-    
-    Hitable *list[4];
 
-    std::size_t i = 0;
-    list[i++] = new Sphere(Vec3(0.0f, -1000.0f, 0.0f), 1000.0f - 0.1f, new Lambertian(Color(0.8f, 0.3f, 0.3f)));
-    list[i++] = new Sphere(Vec3(0.0f, 0.0f, -1.0f), 0.5f, new Lambertian(Color(0.1f, 0.2f, 0.5f)));
-    list[i++] = new Sphere(Vec3(1.0f, 0.0f, -1.0f), 0.5f, new Metal(Color(0.8f, 0.6f, 0.2f), 0.3f));
-    list[i++] = new Sphere(Vec3(-1.0f, 0.0f, -1.0f), 0.5f, new Dielectric(1.5f));
+    Hitable *world = random_scene();
 
-    Hitable *world = new HitableList(list, i);
-
-    auto lookfrom = Vec3{0.0f, 1.5f, 1.0f};
+    auto lookfrom = Vec3{4.0f, 1.5f, 4.0f};
     auto lookat = Vec3{0.0f, 0.0f, -1.0f};
     auto aperture = 0.0f;
     auto focal_length = (Vec3(-2.0f, 2.0f, 1.0f) - Vec3(0.0f, 0.0f, -1.0f)).length();
@@ -42,7 +37,7 @@ int main(int argc, char *argv[])
         lookfrom,
         lookat,
         Vec3::Y,
-        35,
+        50,
         static_cast<float>(image.width()) / static_cast<float>(image.height()),
         aperture,
         focal_length
@@ -105,3 +100,68 @@ Color ray_color(const Ray &r, Hitable *world, int depth)
         return (1.0f - t) * Color(1.0f, 1.0f, 1.0f) + t * Color(0.5f, 0.7f, 1.0f);
     }
 }
+
+
+Hitable *random_scene()
+{
+    auto n = 500;
+    auto **list = new Hitable*[n+1];
+
+    list[0] = new Sphere(
+            {0.0f, -1000.0f, 0.0f},
+            1000,
+            new Lambertian({0.3f, 0.3f, 0.3f})
+    );
+
+    std::size_t i = 1;
+
+    for (auto a = -11; a < 11; ++a)
+    {
+        for (auto b = -11; b < 11; ++b)
+        {
+            auto choose_mat = dist(m);
+            auto center = Vec3{a + 0.9f * dist(m), 0.2f, b + 0.9f * dist(m)};
+
+            if ((center - Vec3{4.0f, 0.2f, 0.0f}).length() > 0.9f)
+            {
+                if (choose_mat < 0.8f)
+                {
+                    list[i++] = new Sphere(
+                            center,
+                            0.2f,
+                            new Lambertian(
+                                    {dist(m) * dist(m), dist(m) * dist(m), dist(m) * dist(m)}
+                            )
+                    );
+                }
+                else if (choose_mat < 0.95f)
+                {
+                    list[i++] = new Sphere(
+                            center,
+                            0.2f,
+                            new Metal(
+                                    {0.5f * (1 + dist(m)), 0.5f * (1 + dist(m)), 0.5f * (1 + dist(m))},
+                                    0.5f * dist(m)
+                            )
+                    );
+                }
+                else
+                {
+                    list[i++] = new Sphere(
+                            center,
+                            0.2f,
+                            new Dielectric(1.5f)
+                    );
+                }
+            }
+        }
+    }
+
+    list[i++] = new Sphere({0.0f, 1.0f, 0.0f}, 1.0f, new Dielectric(1.5));
+    list[i++] = new Sphere({-4.0f, 1.0f, 0.0f}, 1.0f, new Lambertian({0.4f, 0.2f, 0.1f}));
+    list[i++] = new Sphere({4.0f, 1.0f, 0.0f}, 1.0f, new Metal({0.7f, 0.6f, 0.5f}, 0.0f));
+
+    return new HitableList(list, i);
+}
+
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "vec3.h"
 #include "ray.h"
 #include "sphere.h"
+#include "movingsphere.h"
 #include "hitablelist.h"
 #include "camera.h"
 #include "material.h"
@@ -40,7 +41,9 @@ int main(int argc, char *argv[])
         50,
         static_cast<float>(image.width()) / static_cast<float>(image.height()),
         aperture,
-        focal_length
+        focal_length,
+        0.0f,
+        1.0f
     };
 
 	// RANDOM GENERATORS
@@ -126,8 +129,11 @@ Hitable *random_scene()
             {
                 if (choose_mat < 0.8f)
                 {
-                    list[i++] = new Sphere(
+                    list[i++] = new MovingSphere(
                             center,
+                            center + Vec3(0.0f, 0.5f * dist(m), 0.0f),
+                            0.0f, // Time 0
+                            1.0f, // Time 1
                             0.2f,
                             new Lambertian(
                                     {dist(m) * dist(m), dist(m) * dist(m), dist(m) * dist(m)}
@@ -138,6 +144,9 @@ Hitable *random_scene()
                 {
                     list[i++] = new Sphere(
                             center,
+                            // center + Vec3(0.0f, 0.5f * dist(m), 0.0f),
+                            // 0.0f,
+                            // 0.1f,
                             0.2f,
                             new Metal(
                                     {0.5f * (1 + dist(m)), 0.5f * (1 + dist(m)), 0.5f * (1 + dist(m))},
@@ -149,6 +158,9 @@ Hitable *random_scene()
                 {
                     list[i++] = new Sphere(
                             center,
+                            // center + Vec3(0.0f, 0.5f * dist(m), 0.0f),
+                            // 0.0f,
+                            // 0.1f,
                             0.2f,
                             new Dielectric(1.5f)
                     );

--- a/src/material.h
+++ b/src/material.h
@@ -56,7 +56,7 @@ float schlick(float cosine, float ref_idx)
 {
     float r0 = (1 - ref_idx) / (1 + ref_idx);
     r0 = r0 * r0;
-    return r0 + (1 - r0)*pow((1 - cosine), 5);
+    return r0 + (1 - r0) * static_cast<float>(std::pow((1 - cosine), 5));
 }
 
 
@@ -88,7 +88,7 @@ public:
 	virtual bool scatter(const Ray& ray_in, const HitRecord& hit, Color& attenuation, Ray& scattered) const
 	{
 		Vec3 target = hit.p + hit.normal + random_in_unit_sphere();
-		scattered = Ray(hit.p, target - hit.p);
+		scattered = Ray(hit.p, target - hit.p, ray_in.time());
 		attenuation = albedo;
 
 		return true;
@@ -107,7 +107,7 @@ public:
 	virtual bool scatter(const Ray& ray_in, const HitRecord& hit, Color& attenuation, Ray& scattered) const
 	{
 		Vec3 reflected = reflect(unit_vector(ray_in.direction()), hit.normal);
-		scattered = Ray(hit.p, reflected + fuzziness * random_in_unit_sphere());
+		scattered = Ray(hit.p, reflected + fuzziness * random_in_unit_sphere(), ray_in.time());
 		
 		attenuation = albedo;
 
@@ -153,9 +153,9 @@ public:
             reflect_prob = 1.0;
 
         if (dist(m) < reflect_prob)
-            scattered = Ray(hit.p, reflected);
+            scattered = Ray(hit.p, reflected, r_in.time());
         else
-            scattered = Ray(hit.p, refracted);
+            scattered = Ray(hit.p, refracted, r_in.time());
 
         return true;
     }

--- a/src/movingsphere.h
+++ b/src/movingsphere.h
@@ -1,0 +1,101 @@
+#ifndef RAYTRACING_MOVINGSPHERE_H
+#define RAYTRACING_MOVINGSPHERE_H
+
+
+#include "hitable.h"
+#include "material.h"
+
+
+class MovingSphere : public Hitable
+{
+
+private:
+    Vec3 center0, center1;
+    float time0, time1;
+    float radius;
+    Material *mat_ptr;
+
+public:
+
+    /**
+     *
+     */
+    MovingSphere() = default;
+
+    /**
+     *
+     * @param c0
+     * @param c1
+     * @param t0
+     * @param t1
+     * @param r
+     * @param m
+     */
+    MovingSphere(Vec3 c0, Vec3 c1, float t0, float t1, float r, Material *m)
+            : center0{c0}, center1{c1}, time0{t0}, time1{t1}, radius{r}, mat_ptr{m} {};
+
+    /**
+     *
+     * @param r
+     * @param tmin
+     * @param tmax
+     * @param rec
+     * @return
+     */
+    virtual bool hit(const Ray &r, float tmin, float tmax, HitRecord &rec) const;
+
+    /**
+     *
+     * @param time
+     * @return
+     */
+    Vec3 center(float time) const;
+
+};
+
+
+Vec3 MovingSphere::center(float time) const
+{
+    return center0 + ((time - time0) / (time1 - time0)) * (center1 - center0);
+}
+
+
+bool MovingSphere::hit(const Ray &r, float tmin, float tmax, HitRecord &rec) const
+{
+    auto oc = r.origin() - center(r.time());
+    auto a = dot(r.direction(), r.direction());
+    auto b = dot(oc, r.direction());
+    auto c = dot(oc, oc) - radius * radius;
+    auto discriminant = b * b - a * c;
+
+    if (discriminant > 0)
+    {
+        auto temp = (-b - std::sqrt(discriminant)) / a;
+
+        if (temp < tmax && temp > tmin)
+        {
+            rec.t = temp;
+            rec.p = r.point_at_parameter(rec.t);
+            rec.normal = (rec.p - center(r.time())) / radius;
+            rec.mat_ptr = mat_ptr;
+
+            return true;
+        }
+
+        temp = (-b + std::sqrt(discriminant)) / a;
+        if (temp < tmax && temp > tmin)
+        {
+            rec.t = temp;
+            rec.p = r.point_at_parameter(rec.t);
+            rec.normal = (rec.p - center(r.time())) / radius;
+            rec.mat_ptr = mat_ptr;
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
+#endif //RAYTRACING_MOVINGSPHERE_H

--- a/src/ray.h
+++ b/src/ray.h
@@ -25,14 +25,16 @@ class Ray
 private:
     Vec3 a;
     Vec3 b;
+    float t;
 
 public:
     Ray() = default;
-    Ray(const Vec3 &a, const Vec3 &b): a{a}, b{b} {}
+    Ray(const Vec3 &a, const Vec3 &b, float t = 0.0f): a{a}, b{b}, t{t} {}
     ~Ray() = default;
 
     Vec3 origin() const { return a; }
     Vec3 direction() const { return b; }
+    float time() const { return t; }
     Vec3 point_at_parameter(float t) const { return a + t * b; }
 
 };


### PR DESCRIPTION
Rendered motion-blur image:
![test_motionblur](https://user-images.githubusercontent.com/675471/39616015-2e77c0c6-4f71-11e8-9864-97ac9d396969.png)

Updated scene generation.
Only Lambertian spheres are MovingSphere, all other spheres are static, even though the scatter function of all materials will process time information.

Updated readme.

> To generate the test image with enabled motion-blur, the process will take **a lot** of time.