### PR TITLE
Code updates and CPP improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ script:
   - cmake --build .
   - cd ..
   - cp ./resource/sample_texture.jpg .
-  - ./bin/raytracing --samples=1 --width=2 --height=1
+  - ./bin/raytracing --samples=8 --width=4 --height=2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,4 +18,4 @@ build:
 
 test_script:
   - cp .\resource\sample_texture.jpg .
-  - .\bin\%CONFIGURATION%\raytracing.exe --samples=1 --width=2 --height=1
+  - .\bin\%CONFIGURATION%\raytracing.exe --samples=8 --width=4 --height=2

--- a/src/box.h
+++ b/src/box.h
@@ -18,8 +18,8 @@ public:
     Box() = default;
     Box(const Vec3 &p0, const Vec3 &p1, Material *ptr);
 
-    virtual bool hit(const Ray &r, float t0, float t1, HitRecord &rec) const;
-    virtual bool bounding_box(float t0, float t1, AABB &box) const;
+    bool hit(const Ray &r, float t0, float t1, HitRecord &rec) const override;
+    bool bounding_box(float t0, float t1, AABB &box) const override;
 
 };
 
@@ -29,13 +29,15 @@ Box::Box(const Vec3 &p0, const Vec3 &p1, Material *ptr)
     min = p0;
     max = p1;
 
-    Hitable **list = new Hitable*[6];
+    auto **list = new Hitable*[6];
 
     size_t i = 0;
 
+    /*
     auto pxy = new XY_Rect(p0.x(), p1.x(), p0.y(), p1.y(), p1.z(), ptr);
     auto pxz = new XZ_Rect(p0.x(), p1.x(), p0.z(), p1.z(), p1.y(), ptr);
     auto pyz = new YZ_Rect(p0.y(), p1.y(), p0.z(), p1.z(), p1.x(), ptr);
+    */
 
     list[i++] =                 new XY_Rect(p0.x(), p1.x(), p0.y(), p1.y(), p1.z(), ptr);
     list[i++] = new FlipNormals(new XY_Rect(p0.x(), p1.x(), p0.y(), p1.y(), p0.z(), ptr));

--- a/src/bvhnode.h
+++ b/src/bvhnode.h
@@ -20,14 +20,14 @@ private:
 
 public:
     BVHNode() = default;
-    BVHNode(Hitable **l, int n, float time0, float time1);
-    virtual bool hit(const Ray &r, float tmin, float tmax, HitRecord &rec) const;
-    virtual bool bounding_box(float t0, float t1, AABB &b) const;
+    BVHNode(Hitable **l, std::size_t n, float time0, float time1);
+    bool hit(const Ray &r, float tmin, float tmax, HitRecord &rec) const override;
+    bool bounding_box(float t0, float t1, AABB &b) const override;
 
 };
 
 
-BVHNode::BVHNode(Hitable **l, int n, float time0, float time1)
+BVHNode::BVHNode(Hitable **l, std::size_t n, float time0, float time1)
 {
     auto axis = static_cast<int>(3 * dist(m));
 

--- a/src/constantmedium.h
+++ b/src/constantmedium.h
@@ -26,7 +26,7 @@ bool ConstantMedium::hit(const Ray &r, float t_min, float t_max, HitRecord &rec)
 {
     bool db = (dist(m) < 0.00001);
 
-    // db = false; // ???
+    db = false; // ???
 
     HitRecord rec1, rec2;
 

--- a/src/constantmedium.h
+++ b/src/constantmedium.h
@@ -17,8 +17,8 @@ private:
 public:
     ConstantMedium(Hitable *b, float d, Texture *a) : bounday(b), density(d) { phase_function = new Isotropic(a); }
 
-    virtual bool hit(const Ray &r, float t_min, float t_max, HitRecord &rec) const;
-    virtual bool bounding_box(float t0, float t1, AABB &box) const;
+    bool hit(const Ray &r, float t_min, float t_max, HitRecord &rec) const override;
+    bool bounding_box(float t0, float t1, AABB &box) const override;
 
 };
 

--- a/src/hitable.h
+++ b/src/hitable.h
@@ -55,8 +55,8 @@ public:
      */
     Translate(Hitable *p, const Vec3 &displacement): ptr(p), offset(displacement) {}
 
-    virtual bool hit(const Ray &r, float t_min, float t_max, HitRecord &rec) const;
-    virtual bool bounding_box(float t0, float t1, AABB &box) const;
+    bool hit(const Ray &r, float t_min, float t_max, HitRecord &rec) const override;
+    bool bounding_box(float t0, float t1, AABB &box) const override;
 
 };
 
@@ -111,8 +111,8 @@ public:
      */
     RotateY(Hitable *p, float angle);
 
-    virtual bool hit(const Ray &r, float t_min, float t_max, HitRecord &rec) const;
-    virtual bool bounding_box(float t0, float t1, AABB &box) const { box = bbox; return hasbox; }
+    bool hit(const Ray &r, float t_min, float t_max, HitRecord &rec) const override;
+    bool bounding_box(float t0, float t1, AABB &box) const override { box = bbox; return hasbox; }
 
 };
 
@@ -191,9 +191,9 @@ class FlipNormals: public Hitable
 public:
     Hitable *ptr;
 
-    FlipNormals(Hitable *p): ptr(p) {}
+    explicit FlipNormals(Hitable *p): ptr(p) {}
 
-    virtual bool hit(const Ray& r, float t_min, float t_max, HitRecord& rec) const 
+    bool hit(const Ray& r, float t_min, float t_max, HitRecord& rec) const override
     {
         if(ptr->hit(r, t_min, t_max, rec)) 
         {
@@ -204,7 +204,7 @@ public:
             return false;
     }
 
-    virtual bool bounding_box(float t0, float t1, AABB& box) const 
+    bool bounding_box(float t0, float t1, AABB& box) const override
     {
         return ptr->bounding_box(t0, t1, box);
     }

--- a/src/hitablelist.h
+++ b/src/hitablelist.h
@@ -16,8 +16,8 @@ public:
     HitableList() = default;
     HitableList(Hitable **l, std::size_t size) : list{l}, list_size{size} {}
 
-    virtual bool hit(const Ray &r, float tmin, float tmax, HitRecord &rec) const;
-    virtual bool bounding_box(float t0, float t1, AABB &box) const;
+    bool hit(const Ray &r, float tmin, float tmax, HitRecord &rec) const override;
+    bool bounding_box(float t0, float t1, AABB &box) const override;
 
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@ Hitable* random_scene();
 Hitable* test_perlin();
 Hitable* simple_liht();
 Hitable* cornell_box();
+Hitable* light_spheres();
 
 
 int main(int argc, char *argv[])
@@ -41,10 +42,11 @@ int main(int argc, char *argv[])
 
     //Hitable *world = random_scene();
     //Hitable *world = test_perlin();
-    Hitable *world = cornell_box();
+    //Hitable *world = cornell_box();
+    Hitable *world = light_spheres();
 
-    auto lookfrom = Vec3{278.0f, 278.0f, -800.0f};
-    auto lookat = Vec3{278.0f, 278.0f, 0.0f};
+    auto lookfrom = Vec3{10.0f, 20.0f, 10.0f};
+    auto lookat = Vec3{0.0f, 0.0f, 0.0f};
     auto aperture = 0.0f;
     auto focal_length = (Vec3(-2.0f, 2.0f, 1.0f) - Vec3(0.0f, 0.0f, -1.0f)).length();
 
@@ -97,8 +99,10 @@ int main(int argc, char *argv[])
             ipercent = static_cast<int>(std::round(progress * 100.0f));
             if (ipercent != iprevpercent)
             {
+                for (int i=0; i<(ipercent-iprevpercent); ++i)
+                    std::cout << "=" << std::flush;
+
                 iprevpercent = ipercent;
-                std::cout << "=" << std::flush;
             }
 
             col /= static_cast<float>(samples);
@@ -141,7 +145,7 @@ Color ray_color(const Ray &r, Hitable *world, int depth)
 
         Color emitted = rec.mat_ptr->emitted(rec.u, rec.v, rec.p);
 
-        if (depth < 5 && rec.mat_ptr->scatter(r, rec, attenuation, scattered))
+        if (depth < 2 && rec.mat_ptr->scatter(r, rec, attenuation, scattered))
         {
             return emitted + attenuation * ray_color(scattered, world, depth + 1);
         }
@@ -322,4 +326,49 @@ Hitable* cornell_box()
     list[i++] = new ConstantMedium(b2, 0.01f, new ConstantTexture(Color(0.0f, 0.0f, 0.0f)));
 
     return new HitableList(list, i);
+}
+
+
+Hitable* light_spheres()
+{
+    auto **list = new Hitable*[1000];
+    auto idx = std::size_t(0);
+
+    // Top light
+    list[idx++] = new XZ_Rect(-20, 20, -20, 20, 40, new DiffuseLight(new ConstantTexture(Color(0.02f))));
+
+    // Lights
+    for (std::size_t i=0; i<10; ++i)
+    {
+        auto light_color = Color(dist(m) * 10.0f + 20.0f);
+        auto light_material = new DiffuseLight(new ConstantTexture(light_color));
+        auto position = Vec3(
+                (dist(m) * 20.0f) - 5.0f,
+                dist(m) * 2.0f + 0.2f,
+                (dist(m) * 20.0f) - 5.0f
+        );
+        list[idx++] = new Sphere(position, 0.25f, light_material);
+    }
+
+    // Plane
+    list[idx++] = new XZ_Rect(-100, 100, -100, 100, 0, new Lambertian(new ConstantTexture(Color(0.6f, 0.6f, 0.6f))));
+
+    // Spheres
+    for(std::size_t i=0; i<200; ++i)
+    {
+        auto sphere_color = Color(
+                dist(m) * 0.7f + 0.2f,
+                dist(m) * 0.7f + 0.2f,
+                dist(m) * 0.7f + 0.2f
+        );
+        auto sphere_material = new Metal(sphere_color, dist(m) * 0.5f + 0.25f);
+        auto position = Vec3(
+                (dist(m) * 30.0f) - 10.0f,
+                (dist(m) * 4.0f) + 1.0f,
+                (dist(m) * 30.0f) - 10.0f
+        );
+        list[idx++] = new Sphere(position, dist(m) * 1.0f + 0.1f, sphere_material);
+    }
+
+    return new HitableList(list, idx);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,8 @@
 #include <limits>
 #include <random>
 #include <chrono>
+#include <fstream>
+#include <string>
 
 #include "image.h"
 #include "vec3.h"
@@ -70,6 +72,9 @@ int main(int argc, char *argv[])
 
     auto start_time = std::chrono::high_resolution_clock::now();
 
+    auto ipercent = 0;
+    auto iprevpercent = 0;
+
     // IMAGE PROCESSING
     for (int idY=image.height() - 1; idY>=0; --idY)
     {
@@ -88,9 +93,13 @@ int main(int argc, char *argv[])
                 progress += increment;
             }
 
-            std::cout << std::setprecision(3);
-            std::cout << std::fixed;
-            std::cout << "Progress: " << std::setw(7) << progress * 100.0f << "%" << std::endl;
+
+            ipercent = static_cast<int>(std::round(progress * 100.0f));
+            if (ipercent != iprevpercent)
+            {
+                iprevpercent = ipercent;
+                std::cout << "=" << std::flush;
+            }
 
             col /= static_cast<float>(samples);
 
@@ -102,8 +111,9 @@ int main(int argc, char *argv[])
     auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
     auto duration_s = std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time);
 
-    std::clog << "Render time: " << duration_ms.count() << "ms" << std::endl;
-    std::clog << "Render time: " << duration_s.count() << "s" << std::endl;
+    std::cout << std::cout.widen('\n');
+    std::cout << "Render time: " << duration_ms.count() << "ms" << std::cout.widen('\n');
+    std::cout << "Render time: " << duration_s.count() << "s" << std::cout.widen('\n');
 
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,8 +86,11 @@ int main(int argc, char *argv[])
                 col += ray_color(r, world, 0);
 
                 progress += increment;
-                std::cout << "Progress: " << std::setw(5) << progress * 100.0f << "%" << std::endl;
             }
+
+            std::cout << std::setprecision(3);
+            std::cout << std::fixed;
+            std::cout << "Progress: " << std::setw(7) << progress * 100.0f << "%" << std::endl;
 
             col /= static_cast<float>(samples);
 
@@ -99,8 +102,8 @@ int main(int argc, char *argv[])
     auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
     auto duration_s = std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time);
 
-    std::cout << "Render time: " << duration_ms.count() << "ms" << std::endl;
-    std::cout << "Render time: " << duration_s.count() << "s" << std::endl;
+    std::clog << "Render time: " << duration_ms.count() << "ms" << std::endl;
+    std::clog << "Render time: " << duration_s.count() << "s" << std::endl;
 
     return 0;
 }

--- a/src/material.h
+++ b/src/material.h
@@ -89,11 +89,11 @@ Vec3 random_in_unit_sphere()
 class Lambertian : public Material
 {
 public:
-	Lambertian(Texture *a) : albedo(a) {};
+	explicit Lambertian(Texture *a) : albedo(a) {};
 
 	Texture *albedo;
 
-	virtual bool scatter(const Ray& ray_in, const HitRecord& hit, Color& attenuation, Ray& scattered) const
+	bool scatter(const Ray& ray_in, const HitRecord& hit, Color& attenuation, Ray& scattered) const override
 	{
 		Vec3 target = hit.p + hit.normal + random_in_unit_sphere();
 		scattered = Ray(hit.p, target - hit.p, ray_in.time());
@@ -112,7 +112,7 @@ public:
 	Color albedo;
 	float fuzziness;
 
-	virtual bool scatter(const Ray& ray_in, const HitRecord& hit, Color& attenuation, Ray& scattered) const
+	bool scatter(const Ray& ray_in, const HitRecord& hit, Color& attenuation, Ray& scattered) const override
 	{
 		Vec3 reflected = reflect(unit_vector(ray_in.direction()), hit.normal);
 		scattered = Ray(hit.p, reflected + fuzziness * random_in_unit_sphere(), ray_in.time());
@@ -128,9 +128,9 @@ class Dielectric : public Material
 public:
     float ref_idx;
 
-    Dielectric(float ri) : ref_idx(ri) {}
+    explicit Dielectric(float ri) : ref_idx(ri) {}
 
-    virtual bool scatter(const Ray& r_in, const HitRecord& hit, Color& attenuation, Ray& scattered) const
+    bool scatter(const Ray& r_in, const HitRecord& hit, Color& attenuation, Ray& scattered) const override
     {
         Vec3 outward_normal;
         Vec3 reflected = reflect(r_in.direction(), hit.normal);
@@ -176,14 +176,14 @@ class DiffuseLight: public Material
 public:
     Texture *emit;
 
-    DiffuseLight(Texture *a): emit(a) {}
+    explicit DiffuseLight(Texture *a): emit(a) {}
 
-    virtual bool scatter(const Ray& ray_in, const HitRecord& hit, Color& attenuation, Ray& scattered) const 
+    bool scatter(const Ray& ray_in, const HitRecord& hit, Color& attenuation, Ray& scattered) const override
     { 
         return false; 
     }
 
-    virtual Color emitted(float u, float v, const Vec3& p) const
+    Color emitted(float u, float v, const Vec3& p) const override
     {
         return emit->value(u, v, p);
     }
@@ -197,9 +197,9 @@ private:
     Texture *albedo;
 
 public:
-    Isotropic(Texture *a) : albedo(a) {}
+    explicit Isotropic(Texture *a) : albedo(a) {}
 
-    virtual bool scatter(const Ray &r_in, const HitRecord &rec, Color &attenuation, Ray &scattered) const;
+    bool scatter(const Ray &r_in, const HitRecord &rec, Color &attenuation, Ray &scattered) const override;
 
 };
 

--- a/src/movingsphere.h
+++ b/src/movingsphere.h
@@ -20,7 +20,10 @@ public:
     /**
      *
      */
-    MovingSphere() = default;
+    MovingSphere()
+            : time0{0}, time1{1},
+              center0{0.0f, 0.0f, 0.0f}, center1{0.0f, 0.0f, 0.0f},
+              radius{1.0f}, mat_ptr{nullptr} {};
 
     /**
      *
@@ -42,7 +45,7 @@ public:
      * @param rec
      * @return
      */
-    virtual bool hit(const Ray &r, float tmin, float tmax, HitRecord &rec) const;
+    bool hit(const Ray &r, float tmin, float tmax, HitRecord &rec) const override;
 
 
     /**
@@ -52,7 +55,7 @@ public:
      * @param box
      * @return
      */
-    virtual bool bounding_box(float t0, float t1, AABB &box) const;
+    bool bounding_box(float t0, float t1, AABB &box) const override;
 
 
     /**

--- a/src/ray.h
+++ b/src/ray.h
@@ -2,9 +2,6 @@
 #define RAYTRACING_RAY_H
 
 
-#include <cmath>
-
-
 #include "vec3.h"
 #include "color.h"
 

--- a/src/rect.h
+++ b/src/rect.h
@@ -15,12 +15,12 @@ private:
     float k;
 
 public:
-    XY_Rect() = default;
+    XY_Rect(): x0{-1.0f}, y0{-1.0f}, x1{1.0f}, y1{1.0f}, k{0}, material{nullptr} {};
     XY_Rect(float x0, float x1, float y0, float y1, float k, Material *material)
             : x0(x0), x1(x1), y0(y0), y1(y1), k(k), material(material) {}
 
-    virtual bool hit(const Ray &r, float t0, float t1, HitRecord &rec) const;
-    virtual bool bounding_box(float t0, float t1, AABB &box) const;
+    bool hit(const Ray &r, float t0, float t1, HitRecord &rec) const override;
+    bool bounding_box(float t0, float t1, AABB &box) const override;
 
 };
 
@@ -66,12 +66,12 @@ private:
     float k;
 
 public:
-    XZ_Rect() = default;
+    XZ_Rect(): x0{-1.0f}, z0{-1.0f}, x1{1.0f}, z1{1.0f}, k{0}, material{nullptr} {};
     XZ_Rect(float x0, float x1, float z0, float z1, float k, Material *material)
             : x0(x0), x1(x1), z0(z0), z1(z1), k(k), material(material) {}
 
-    virtual bool hit(const Ray &r, float t0, float t1, HitRecord &rec) const;
-    virtual bool bounding_box(float t0, float t1, AABB &box) const;
+    bool hit(const Ray &r, float t0, float t1, HitRecord &rec) const override;
+    bool bounding_box(float t0, float t1, AABB &box) const override;
 
 };
 
@@ -117,12 +117,12 @@ private:
     float k;
 
 public:
-    YZ_Rect() = default;
+    YZ_Rect(): y0{-1.0f}, z0{-1.0f}, y1{1.0f}, z1{1.0f}, k{0}, material{nullptr} {};
     YZ_Rect(float y0, float y1, float z0, float z1, float k, Material *material)
             : y0(y0), y1(y1), z0(z0), z1(z1), k(k), material(material) {}
 
-    virtual bool hit(const Ray &r, float t0, float t1, HitRecord &rec) const;
-    virtual bool bounding_box(float t0, float t1, AABB &box) const;
+    bool hit(const Ray &r, float t0, float t1, HitRecord &rec) const override;
+    bool bounding_box(float t0, float t1, AABB &box) const override;
 
 };
 

--- a/src/sphere.h
+++ b/src/sphere.h
@@ -4,8 +4,6 @@
 #include "hitable.h"
 #include "material.h"
 
-#define M_PI 3.14159265358979323846
-
 
 void get_sphere_uv(const Vec3& p, float& u, float& v)
 {
@@ -26,11 +24,11 @@ private:
     Material *mat_ptr;
 
 public:
-    Sphere() = default;
+    Sphere(): center{0.0f, 0.0f, 0.0f}, radius{1}, mat_ptr{nullptr} {};
     Sphere(Vec3 center, float radius, Material *mat) : center{ center }, radius{ radius }, mat_ptr{ mat } {}
 
-    virtual bool hit(const Ray &r, float tmin, float tmax, HitRecord &rec) const;
-	virtual bool bounding_box(float t0, float t1, AABB &box) const;
+    bool hit(const Ray &r, float tmin, float tmax, HitRecord &rec) const override;
+    bool bounding_box(float t0, float t1, AABB &box) const override;
 
 };
 

--- a/src/texture.h
+++ b/src/texture.h
@@ -32,13 +32,13 @@ class ConstantTexture: public Texture
 class CheckerTexture: public Texture
 {
     public:
-        CheckerTexture() {}
+        CheckerTexture() = default;
 
         CheckerTexture(Texture *t0, Texture *t1): even(t0), odd(t1) {}
 
-        virtual Color value(float u, float v, const Vec3& p) const
+        virtual Color value(float u, float v, const Vec3& p) const override
         {
-            float sines = sin(10*p.x()) * sin(10*p.y()) *sin(10*p.z());
+            float sines = std::sinf(10*p.x()) * std::sinf(10*p.y()) * std::sinf(10*p.z());
 
             if (sines < 0)
                 return odd->value(u, v, p);

--- a/src/texture.h
+++ b/src/texture.h
@@ -38,7 +38,7 @@ class CheckerTexture: public Texture
 
         virtual Color value(float u, float v, const Vec3& p) const override
         {
-            float sines = std::sinf(10*p.x()) * std::sinf(10*p.y()) * std::sinf(10*p.z());
+            float sines = std::sin(10*p.x()) * std::sin(10*p.y()) * std::sin(10*p.z());
 
             if (sines < 0)
                 return odd->value(u, v, p);


### PR DESCRIPTION
@Ale32 
To properly check and speed up the application I made some fixes.

First of all, removed almost all the `std::cout` I could, as well as all the `std::endl` [because of this](https://kuhllib.com/2012/01/14/stop-excessive-use-of-stdendl/), and [this](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rio-endl).

Then, to be `C++17` compatible, I removed all the `virtual` redeclaration of `virtual` methods, replacing the child class methods with `override` (this way is more understandable which is the original declaration and which one is the override one.

Then I replaces some variable declaration with `auto` because of what stated in the [Cpp Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es11-use-auto-to-avoid-redundant-repetition-of-type-names).

There where some other issues with type checks (`std::size_t` compared with `int` - unsigned compared to signed) and I fixed those as well.

Converted some constructor into `explicit` ones.

> About this, we should strongly follow [this](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es64-use-the-tenotation-for-construction), from now on.
> This way, for us, would be more easy to generate good code that is both compatible with the new C++ standards, and extremely understandable regarding what it does.

About constructors, some of them was declared as default constructors:
```C++
class Sphere
{
private:
    float radius;
    Vec3 center;
public:
    Sphere() = default;
};
```
But this way the private attributes of the class was not initialised.
We can solve this problem by either removing the default empty constructors:
```C++
public:
    Sphere() = delete;
    Sphere(Vec3 center, float radius);
```
Or by initialising the attributes with some default values:
```C++
public:
    Sphere() : center{0.0f, 0.0f, 0.0f}, radius{1.0f} {}
    Sphere(Vec3 center, float radius);
```
I've done the second because I thought that, maybe, we want to use the "instancing" system in place to move the objects around, without the needs of always define those objects at the origin (for example).

> This needs a more thorough revisitation of the `Texture` derived classes, because a default value in those objects require some (non-trivial) thinking.

Also:
- [Use `std::string` to own character sequences](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#slstr1-use-stdstring-to-own-character-sequences)
- [Use `std::string_view` to refer to character sequences](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#slstr2-use-stdstring_view-or-gslstring_span-to-refer-to-character-sequences)
- [Use the `s` suffix for string literals](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#slstr12-use-the-s-suffix-for-string-literals-meant-to-be-standard-library-strings)
- [Non-Rules and miths](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#nr-non-rules-and-myths).